### PR TITLE
Fix typo in footer

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -30,7 +30,7 @@
   {% endfor %}
   </main>
   <footer>
-    Made with <img class="netliheart" title="love" src="/images/netliheart.svg" alt="love" width="1em"> by the <a href="https://netlify.com?utm_source=web&utm_medium=petsofnetlify-pnh&utm_campaign=devex">Netlify</a> team. Explore <a href="https://github.com/netlify/petsofnetlify">the code</a> in GitHub. Follow <a href="https://twitter.com/netlify">@Netliify</a> on Twitter for regular updates</a>.
+    Made with <img class="netliheart" title="love" src="/images/netliheart.svg" alt="love" width="1em"> by the <a href="https://netlify.com?utm_source=web&utm_medium=petsofnetlify-pnh&utm_campaign=devex">Netlify</a> team. Explore <a href="https://github.com/netlify/petsofnetlify">the code</a> in GitHub. Follow <a href="https://twitter.com/netlify">@Netlify</a> on Twitter for regular updates</a>.
   </footer>
 </body>
 </html>


### PR DESCRIPTION
Typo in footer. Change twitter text from "@Netliify" to "@Netlify" (removed the extra i)