### PR TITLE
Fix image stretching

### DIFF
--- a/src/_includes/style.css
+++ b/src/_includes/style.css
@@ -35,6 +35,7 @@ h2 {
   box-shadow: 1px 0px 10px 0px rgba(0,0,0,0.2);
   padding: 2px;
   margin: 10px;
+  align-self: center;
 }
 
 .pet:target img {


### PR DESCRIPTION
When pet names are longer than their image, the image stretches to fill the new size, and distorts the image. Flexbox likes to make images stretch unless you specify otherwise 😅. So here's that quick fix!